### PR TITLE
Add support for custom matchers

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -14,3 +14,17 @@ exports[`jest-expect-message should fail without custom message 1`] = `
 
 Received: [31mfalse[39m"
 `;
+
+exports[`jest-expect-message supports custom matchers registered after jest-expect-message allows new custom matchers to use custom messages 1`] = `
+"Custom message:
+  100 % 3 === 1
+
+expected 100 to be divisible by 3"
+`;
+
+exports[`jest-expect-message supports custom matchers registered after jest-expect-message allows new custom matchers to use custom messages 2`] = `
+"Custom message:
+  101 % 1 === 0
+
+expected 101 not to be divisible by 1"
+`;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -8,4 +8,36 @@ describe('jest-expect-message', () => {
   test('should fail without custom message', () => {
     expect(() => expect(false).toBeTruthy()).toThrowErrorMatchingSnapshot();
   });
+
+  test('should pass when given custom message', () => {
+    expect(1, 'should have been 1').toBe(1);
+  });
+
+  test('should pass when not given custom message', () => {
+    expect(1).toBe(1);
+  });
+
+  describe('supports custom matchers registered after jest-expect-message', () => {
+    expect.extend({
+      toBeDivisibleBy(received, argument) {
+        const pass = received % argument == 0;
+        const message = pass
+          ? () => `expected ${received} not to be divisible by ${argument}`
+          : () => `expected ${received} to be divisible by ${argument}`;
+        return { message, pass };
+      }
+    });
+
+    it('allows new custom matchers to use custom messages', () => {
+      expect(() => expect(100, '100 % 3 === 1').toBeDivisibleBy(3)).toThrowErrorMatchingSnapshot();
+      expect(() => expect(101, '101 % 1 === 0').not.toBeDivisibleBy(1)).toThrowErrorMatchingSnapshot();
+    });
+
+    it('supports custom asymmetric matchers', () => {
+      expect({ apples: 6, bananas: 3 }).toEqual({
+        apples: expect.toBeDivisibleBy(1),
+        bananas: expect.not.toBeDivisibleBy(2)
+      });
+    });
+  });
 });

--- a/src/withMessage.js
+++ b/src/withMessage.js
@@ -50,6 +50,16 @@ const wrapMatchers = (matchers, customMessage) => {
 };
 
 export default expect => {
-  const expectProxy = (actual, customMessage) => wrapMatchers(expect(actual), customMessage); // partially apply expect to get all matchers and wrap them
-  return Object.assign(expectProxy, expect); // clone additional properties on expect
+  // proxy the expect function
+  let expectProxy = Object.assign(
+    (actual, customMessage) => wrapMatchers(expect(actual), customMessage), // partially apply expect to get all matchers and chain them
+    expect // clone additional properties on expect
+  );
+
+  expectProxy.extend = o => {
+    expect.extend(o); // add new matchers to expect
+    expectProxy = Object.assign(expectProxy, expect); // clone new asymmetric matchers
+  };
+
+  return expectProxy;
 };

--- a/src/withMessage.test.js
+++ b/src/withMessage.test.js
@@ -7,11 +7,10 @@ describe('withMessage()', () => {
     expect.assertions(3);
     const toBeMock = jest.fn();
     const expectMock = jest.fn(() => ({ toBe: toBeMock }));
-    expectMock.extend = 'extend';
-
+    expectMock.any = 'any';
     const newExpect = withMessage(expectMock);
     newExpect(ACTUAL, 'should fail').toBe(ACTUAL);
-    expect(newExpect.extend).toBe('extend');
+    expect(newExpect.any).toBe('any');
     expect(expectMock).toHaveBeenCalledWith(ACTUAL);
     expect(toBeMock).toHaveBeenCalledWith(ACTUAL);
   });
@@ -126,5 +125,35 @@ describe('withMessage()', () => {
       expect(expectMock).toHaveBeenCalledWith(ACTUAL);
       expect(toBeMock).toHaveBeenCalledWith(ACTUAL);
     }
+  });
+
+  it('calls original expect.extend when custom matcher is registered', () => {
+    const extendMock = jest.fn();
+    const expectMock = jest.fn();
+    expectMock.extend = extendMock;
+    const newMatcher = { newMatcher: 'woo' };
+
+    withMessage(expectMock).extend(newMatcher);
+
+    expect(extendMock).toHaveBeenCalledTimes(1);
+    expect(extendMock).toHaveBeenCalledWith(newMatcher);
+  });
+
+  it('sets new asymmetric matchers when custom matcher is registered with expect.extend', () => {
+    const expectMock = () => {};
+    const extendMock = jest.fn(o => Object.assign(expectMock, o));
+    expectMock.a = 'a';
+    expectMock.extend = extendMock;
+    const newMatcher = { newMatcher: 'woo' };
+
+    const actual = withMessage(expectMock);
+
+    expect(actual).toContainAllKeys(['a', 'extend']);
+
+    actual.extend(newMatcher);
+
+    expect(extendMock).toHaveBeenCalledTimes(1);
+    expect(extendMock).toHaveBeenCalledWith(newMatcher);
+    expect(actual).toContainAllKeys(['a', 'extend', 'newMatcher']);
   });
 });


### PR DESCRIPTION
Fixes bug where custom asymmetric matchers are not assigned to the `expect` API
