### PR TITLE
Feature/add support object type message

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -9,6 +9,15 @@ exports[`jest-expect-message should fail with custom message 1`] = `
 Received: [31mfalse[39m"
 `;
 
+exports[`jest-expect-message should fail with obj custom message 1`] = `
+"Custom message:
+  {\\"data\\":{\\"orederId\\":1}}
+
+[2mexpect([22m[31mreceived[39m[2m).toBeTruthy([22m[2m)[22m
+
+Received: [31mfalse[39m"
+`;
+
 exports[`jest-expect-message should fail without custom message 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeTruthy([22m[2m)[22m
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -5,6 +5,10 @@ describe('jest-expect-message', () => {
     expect(() => expect(false, 'Woah this should be false!').toBeTruthy()).toThrowErrorMatchingSnapshot();
   });
 
+  test('should fail with obj custom message', () => {
+    expect(() => expect(false, { data: { orederId: 1 } }).toBeTruthy()).toThrowErrorMatchingSnapshot();
+  });
+
   test('should fail without custom message', () => {
     expect(() => expect(false).toBeTruthy()).toThrowErrorMatchingSnapshot();
   });

--- a/src/withMessage.js
+++ b/src/withMessage.js
@@ -19,6 +19,9 @@ const wrapMatcher = (matcher, customMessage) => {
       }
       const { matcherResult } = error;
 
+      if (typeof customMessage === 'object') {
+        customMessage = JSON.stringify(customMessage);
+      }
       if (typeof customMessage !== 'string' || customMessage.length < 1) {
         throw new JestAssertionError(matcherResult, newMatcher);
       }


### PR DESCRIPTION
<!-- What changes are being made? (feature/bug) -->
### What

When the message is an object, it is JSON.stringify

<!-- Why are these changes necessary? Link any related issues -->
### Why

When I check a property of an object, I want to prompt the entire object when the error occurs.

Without having to use JSON.stringify every time.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings