### PR TITLE
Fix performance problem when wrapping matchers. Fixes #24

### DIFF
--- a/src/withMessage.js
+++ b/src/withMessage.js
@@ -36,16 +36,12 @@ const wrapMatchers = (matchers, customMessage) => {
     const matcher = matchers[name];
 
     if (typeof matcher === 'function') {
-      return {
-        ...acc,
-        [name]: wrapMatcher(matcher, customMessage)
-      };
+      acc[name] = wrapMatcher(matcher, customMessage);
+    } else {
+      acc[name] = wrapMatchers(matcher, customMessage); // recurse on .not/.resolves/.rejects
     }
 
-    return {
-      ...acc,
-      [name]: wrapMatchers(matcher, customMessage) // recurse on .not/.resolves/.rejects
-    };
+    return acc;
   }, {});
 };
 

--- a/src/withMessage.js
+++ b/src/withMessage.js
@@ -48,7 +48,15 @@ const wrapMatchers = (matchers, customMessage) => {
 export default expect => {
   // proxy the expect function
   let expectProxy = Object.assign(
-    (actual, customMessage) => wrapMatchers(expect(actual), customMessage), // partially apply expect to get all matchers and chain them
+    (actual, customMessage) => {
+      let matchers = expect(actual); // partially apply expect to get all matchers and chain them
+      if (customMessage) {
+        // only pay the cost of proxying matchers if we received a customMessage
+        matchers = wrapMatchers(matchers, customMessage);
+      }
+
+      return matchers;
+    },
     expect // clone additional properties on expect
   );
 


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
Removed the destructuring assignment from inside the `wrapMathcers()` loop that was significantly slowing down tests when using this library.

<!-- Why are these changes necessary? Link any related issues -->
### Why
Fixes #24 - create and return a single object instead of creating a new object and re-copying all previous properties on every iteration of the loop.

The destructuring code was accidentally quadratic to the number of matcher properties.
This changes it back to linear to the number of matchers.

<!-- If necessary add any additional notes on the implementation -->
### Notes
No functional changes, just quicker :)

### Housekeeping

- [x] Unit tests - no extra tests needed
- [x] Documentation is up to date - no change to documentation needed
- [x] No additional lint warnings