### PR TITLE
Fix return type to include 'resolves', 'rejects', and 'not' properties

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,6 @@ declare namespace jest {
       actual: T,
       message?: string,
       options?: { showMatcherMessage?: boolean; showPrefix?: boolean; showStack?: boolean }
-    ): Matchers<T>;
+    ): JestMatchers<T>;
   }
 }


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
Changing the return type in the TypeScript declaration to be `JestMatchers<T>`.

<!-- Why are these changes necessary? Link any related issues -->
### Why
This is in line with the original type declaration in `@types/jest`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c3924fd0016c953e1c4440f102436694442b7a57/types/jest/index.d.ts#L626

With this type the return type will then also include the `resolves`, `rejects` and `not` properties, which would not be included when using the `Matchers<T>` return type.

<!-- If necessary add any additional notes on the implementation -->
### Notes

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings