### PR TITLE
exporting global expect constant

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,3 +7,5 @@ declare namespace jest {
     ): JestMatchers<T>;
   }
 }
+
+declare const expect: jest.Expect;


### PR DESCRIPTION
otherwise in some editors (in my case vim tsserver LSP), the global type is still native jest type, and so additional parameters are not honored

by exporting expect constant, that makes it explicit that global expect is overwritten

<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What

exporting global `expect` constant for typescript support

<!-- Why are these changes necessary? Link any related issues -->
### Why

Some LSP servers do not pickup updated `expect` global and so complain that additional parameters are not supported

<!-- If necessary add any additional notes on the implementation -->
### Notes

### Housekeeping

- [ ] ~~Unit tests~~
- [ ] ~~Documentation is up to date~~
- [ ] ~~No additional lint warnings~~