### PR TITLE
Allow customMessage to be a function that returns message

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,22 @@ Expect takes at most one argument.
 
 ## Solution
 
-`jest-expect-message` allows you to call `expect` with a second argument of a `String` message.
+`jest-expect-message` allows you to call `expect` with a second argument of a `String` message or `function`.
 
 For example the same test as above:
 
 ```js
 test('returns 2 when adding 1 and 1', () => {
   expect(1 + 1, 'Woah this should be 2!').toBe(3);
+});
+```
+
+Or you can pass a function that generates and returns the extra message:
+
+```js
+test('returns 2 when adding 1 and 1', () => {
+  const context = 2;
+  expect(1 + 1, () => (`Woah this should be ${context}!`)).toBe(3);
 });
 ```
 

--- a/src/__snapshots__/withMessage.test.js.snap
+++ b/src/__snapshots__/withMessage.test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`withMessage() calls custom message function when matcher fails 1`] = `
+"Custom message:
+  custom message from function
+
+expected ACTUAL to be 1"
+`;
+
 exports[`withMessage() throws error with custom message when matcher fails 1`] = `
 "Custom message:
   should fail

--- a/src/withMessage.js
+++ b/src/withMessage.js
@@ -9,7 +9,7 @@ class JestAssertionError extends Error {
   }
 }
 
-const wrapMatcher = (matcher, customMessage, config) => {
+const wrapMatcher = (matcher, customMessageOrFn, config) => {
   const newMatcher = (...args) => {
     try {
       const result = matcher(...args);
@@ -30,7 +30,8 @@ const wrapMatcher = (matcher, customMessage, config) => {
         throw error;
       }
       const { matcherResult } = error;
-
+      
+      const customMessage = typeof customMessageOrFn === 'function' ? customMessageOrFn() : customMessageOrFn;
       if (typeof customMessage !== 'string' || customMessage.length < 1) {
         throw new JestAssertionError(matcherResult, newMatcher);
       }

--- a/src/withMessage.test.js
+++ b/src/withMessage.test.js
@@ -98,6 +98,37 @@ describe('withMessage()', () => {
     }
   });
 
+  test('calls custom message function when matcher fails', () => {
+    expect.assertions(5);
+    const originalError = new Error('Boo');
+    originalError.matcherResult = {
+      actual: ACTUAL,
+      expected: 1,
+      message: () => 'expected ACTUAL to be 1',
+      pass: false
+    };
+
+    const toBeMock = jest.fn(() => {
+      throw originalError;
+    });
+    const expectMock = jest.fn(() => ({ toBe: toBeMock }));
+
+    const customMessageFn = jest.fn(() => 'custom message from function');
+    try {
+      withMessage(expectMock)(ACTUAL, customMessageFn).toBe(1);
+    } catch (e) {
+      expect(e.matcherResult).toMatchObject({
+        actual: ACTUAL,
+        expected: 1,
+        pass: false
+      });
+      expect(e.message).toMatchSnapshot();
+      expect(customMessageFn).toHaveBeenCalled();
+      expect(expectMock).toHaveBeenCalledWith(ACTUAL);
+      expect(toBeMock).toHaveBeenCalledWith(1);
+    }
+  });
+
   test('throws error with custom message when not matcher fails', () => {
     expect.assertions(4);
     const originalError = new Error('Boo');

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@ declare namespace jest {
   interface Expect {
     <T = any>(
       actual: T,
-      message?: string,
+      message?: string | (() => string),
       options?: { showMatcherMessage?: boolean; showPrefix?: boolean; showStack?: boolean }
     ): JestMatchers<T>;
   }


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What

Feature: allow the `customMessage` parameter to be passed a function as well as a string

```
// Original (and still supported)
expect(value, `custom message string`).toBe(actual);

// New: allow a function that returns the message
expect(value, () => (`custom message from function`)).toBe(actual);
```

<!-- Why are these changes necessary? Link any related issues -->
### Why

This allows the generation of `customMessage` to be lazy - i.e. the message will only be generated if the expectation failed.

If the message generation is expensive to do then the cost is only incurred when the test failed.

This also makes the `customMessage` API more consistent with Jest v27+ that requires the `matcher.message` property to be a function.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings