### PR TITLE
Fixes build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add custom message to Jest expects
 
 <hr />
 
-[![Build Status](https://img.shields.io/github/workflow/status/mattphillips/jest-expect-message/GitHub%20CI/main?style=flat-square)](https://github.com/mattphillips/jest-expect-message/actions/workflows/ci.yaml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/mattphillips/jest-expect-message/ci.yaml?branch=main&style=flat-square)](https://github.com/mattphillips/jest-expect-message/actions/workflows/ci.yaml)
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattphillips/jest-expect-message.svg?style=flat-square)](https://codecov.io/github/mattphillips/jest-expect-message)
 [![version](https://img.shields.io/npm/v/jest-expect-message.svg?style=flat-square)](https://www.npmjs.com/package/jest-expect-message)
 [![downloads](https://img.shields.io/npm/dm/jest-expect-message.svg?style=flat-square)](http://npm-stat.com/charts.html?package=jest-expect-message&from=2017-09-14)


### PR DESCRIPTION



### What

Currently the build badge on the `README.md` is broken, showing a link to an issue:

![image](https://user-images.githubusercontent.com/4732915/234641554-e587974e-7719-4c33-ae78-1268ae286d8a.png)

I suggest a fix for the badge URL.

### Why

There's a new URL for the badge image, see See badges/shields#8671

