### PR TITLE
chore: improve Configure TypeScript section in the readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thanks for being willing to contribute!
 
 Once you are ready to commit the changes, please use the below commands
 
-1. `git add <files to be comitted>`
+1. `git add <files to be committed>`
 2. `git commit -m 'A meaningful message`
 
 _Note: please use present tense in commit messages i.e. `Add feature X` and not ~`Added feature X`~_

--- a/README.md
+++ b/README.md
@@ -104,19 +104,33 @@ If you have a custom setup file and want to use this library then add the follow
 import 'jest-expect-message';
 ```
 
-### Configure Typescript
+### Configure TypeScript
 
-Add the following entry to your tsconfig to enable Typescript support.
+If you keep the `types` list of the `compilerOptions` explicit, add `jest-expect-message` to it:
 
 ```json
-  "files": ["node_modules/jest-expect-message/types/index.d.ts"],
+{
+  "compilerOptions": {
+    "types": ["jest", "jest-expect-message"]
+  }
+}
 ```
 
-#### Example
+Alternatively if you prefer letting TypeScript to discover the `@types/*` packages automatically, declare `jest-expect-message` as an `@types/*` package in `package.json`:
 
-Custom message [example](/example) with typescript
+```json
+{
+  "devDependencies": {
+    "@types/jest-expect-message": "npm:jest-expect-message@*",
+  }
+}
+```
 
-### Configure ESlint
+After adding the line, remember to run `npm install`, `yarn install` or `pnpm install`, depending on your package manager.
+
+For reference, see the [example](/examples/typescript/) with TypeScript.
+
+### Configure ESLint
 
 ```json
 "rules": {

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -10,6 +10,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/jest": "^29.0.0",
+    "@types/jest-expect-message": "npm:jest-expect-message@*",
     "jest": "^29.0.2",
     "jest-expect-message": "^1.1.3",
     "ts-jest": "^28.0.8",

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -12,7 +12,6 @@
     "noEmit": true
   },
 
-  "files": ["node_modules/jest-expect-message/types/index.d.ts"],
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"]
 }

--- a/examples/typescript/yarn.lock
+++ b/examples/typescript/yarn.lock
@@ -643,6 +643,11 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest-expect-message@npm:jest-expect-message@*", jest-expect-message@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/jest-expect-message/-/jest-expect-message-1.1.3.tgz#a3f6bd4503f5bd5d2e37b70d3126a2bdb215ec58"
+  integrity sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==
+
 "@types/jest@^29.0.0":
   version "29.0.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.0.0.tgz#bc66835bf6b09d6a47e22c21d7f5b82692e60e72"
@@ -1383,11 +1388,6 @@ jest-environment-node@^29.0.2:
     "@types/node" "*"
     jest-mock "^29.0.2"
     jest-util "^29.0.2"
-
-jest-expect-message@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/jest-expect-message/-/jest-expect-message-1.1.3.tgz#a3f6bd4503f5bd5d2e37b70d3126a2bdb215ec58"
-  integrity sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==
 
 jest-get-type@^29.0.0:
   version "29.0.0"


### PR DESCRIPTION
### What

This PR is a suggestion to improve Configure TypeScript section in the readme.

### Why

Technically there is no problem, all works well as documented. It just does not look elegant to reach into `node_modules` instead of letting package manager and TypeScript do the job. The improvement is subjective, of course.

### Housekeeping

- [x] Documentation is up to date
- [x] No additional lint warnings