### PR TITLE
README.md: Increase maxArgs for jest/valid-expect

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Custom message [example](/example) with typescript
   "jest/valid-expect": [
     "error",
     {
-      "maxArgs": 2
+      "maxArgs": 3
     }
   ]
 }


### PR DESCRIPTION
<!-- What changes are being made? (feature/bug) -->
### What
Documentation only.

<!-- Why are these changes necessary? Link any related issues -->
### Why
EsLint rule `jest/valid-expect` should be configured to accept up to 3 args to support the "options" arg.
